### PR TITLE
Fix issue with single quotes for Java MessageFormat

### DIFF
--- a/src/main/scala/Messages.scala
+++ b/src/main/scala/Messages.scala
@@ -27,7 +27,7 @@ object Messages {
   /** get the message w/o formatting */
   def raw(msg: String)(implicit lang: Lang): String = {
     val bundle = ResourceBundle.getBundle(FileName, lang.locale, UTF8BundleControl)
-    bundle.getString(msg)
+    bundle.getString(msg).replaceAll("'", "''")
   }
 
   def apply(msg: String, args: Any*)(implicit lang: Lang): String = {


### PR DESCRIPTION
It would be an alternative fix to replace apostrophes in the messages.txt file with 2x apostrophes, but these files are being sent to our translators; we don't want to bother them with technical details.

An alternative would be to replace apostrophes with the pretty single quote (’ U+2019), but that might change the intent.
