### PR TITLE
cross-compile for scala3 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,14 @@ homepage := Some(url("https://github.com/osinka/scala-i18n"))
 
 startYear := Some(2014)
 
-scalaVersion := "2.13.0"
+val Scala211 = "2.11.12"
+val Scala212 = "2.12.19"
+val Scala213 = "2.13.14"
+val Scala3 = "3.5.0"
 
-crossScalaVersions := Seq("2.11.11", "2.12.8", "2.13.0")
+scalaVersion := Scala213
+
+crossScalaVersions := Seq(Scala211, Scala212, Scala213, Scala3)
 
 licenses += "Apache License, Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")
 
@@ -18,9 +23,7 @@ description := """Play-like internationalized messages for any Scala"""
 
 scalacOptions ++= List("-deprecation", "-unchecked", "-feature")
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.0.8" % "test"
-)
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.2.19" % Test)
 
 credentials += {
   val file =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.10.1

--- a/src/main/scala/Localized.scala
+++ b/src/main/scala/Localized.scala
@@ -40,7 +40,7 @@ object Localized {
     fn( localized.locale(a) )
   }
 
-  implicit def optionLocalized[T](implicit localized: Localized[T]) =
+  implicit def optionLocalized[T](implicit localized: Localized[T]): Localized[Option[T]] =
     new Localized[Option[T]] {
       override def locale(o: Option[T]) =
         o map(localized.locale) getOrElse Lang.Default

--- a/src/test/scala/messagesSpec.scala
+++ b/src/test/scala/messagesSpec.scala
@@ -1,8 +1,10 @@
 package com.osinka.i18n
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers._
 
-class messagesSpec extends FunSpec with Matchers {
+class messagesSpec extends AnyFunSpec with Matchers {
   val EN = Lang("en")
   val RU = Lang("ru")
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-ThisBuild / version := "1.0.4-SNAPSHOT"
+ThisBuild / version := "1.1.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,2 +1,2 @@
 
-version in ThisBuild := "1.0.4-SNAPSHOT"
+ThisBuild / version := "1.0.4-SNAPSHOT"


### PR DESCRIPTION
I created a cross-compiled version for Scala 3 to resolve issue #10. It seems to work, I was able to use it in a Scala 3 project as well.